### PR TITLE
Android security 11.0.0 release 62

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -23,6 +23,7 @@
     <protected-broadcast android:name="android.intent.action.SHOW_MISSED_CALLS_NOTIFICATION" />
     <protected-broadcast android:name="com.android.server.telecom.MESSAGE_SENT" />
 
+    <uses-permission android:name="android.permission.HIDE_NON_SYSTEM_OVERLAY_WINDOWS"/>
 
     <!-- Prevents the activity manager from delaying any activity-start
          requests by this package, including requests immediately after

--- a/src/com/android/server/telecom/settings/EnableAccountPreferenceActivity.java
+++ b/src/com/android/server/telecom/settings/EnableAccountPreferenceActivity.java
@@ -25,11 +25,15 @@ import android.telecom.Log;
 import android.telecom.PhoneAccountHandle;
 import android.telecom.TelecomManager;
 import android.view.MenuItem;
+import android.view.WindowManager;
 
 public class EnableAccountPreferenceActivity extends Activity {
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        getWindow().addSystemFlags(
+                android.view.WindowManager.LayoutParams
+                        .SYSTEM_FLAG_HIDE_NON_SYSTEM_OVERLAY_WINDOWS);
 
         getFragmentManager().beginTransaction()
                 .replace(android.R.id.content, new EnableAccountPreferenceFragment())


### PR DESCRIPTION
Merge tag 'android-security-11.0.0_r62' of https://android.googlesource.com/platform/packages/services/Telecomm into arrow-11.0

Android security 11.0.0 release 62
Tag: https://android.googlesource.com/platform/packages/services/Telecomm/+/refs/tags/android-security-11.0.0_r62

Merge cherrypicks of [20069028] into security-aosp-rvc-release.

Change-Id: [I775f7cff16fce2c42d05a71e2594271657134960](https://android-review.googlesource.com/#/q/I775f7cff16fce2c42d05a71e2594271657134960)